### PR TITLE
Markup fix for spellexception

### DIFF
--- a/style-guide.rst
+++ b/style-guide.rst
@@ -788,7 +788,7 @@ This role is part of the ``custom-rst-roles`` extension.
 
    * - Input
      - Output
-   * - ``:spellexception:\`PurposelyWrong\```
+   * - ``:spellexception:`PurposelyWrong```
      - :spellexception:`PurposelyWrong`
 
 Terminal output


### PR DESCRIPTION
Tiny change to fix the rendering of this:
![image](https://github.com/canonical/sphinx-docs-guide/assets/6623103/e917f2b5-be26-40b8-8be3-fde4aed2ccac)
