### PR TITLE
Update list style-guide

### DIFF
--- a/style-guide-myst.md
+++ b/style-guide-myst.md
@@ -423,6 +423,22 @@ To exclude pages from the build, add them to the `custom_excludes` variable in t
     1. Step 2
        1. Sub-step 1
        1. Sub-step 2
+* - ```
+    This is a sentence.
+
+    1. Step 1
+    1. Step 2
+    1. Step 3
+
+    Another sentence follows.
+    ```
+  - This is a sentence.
+
+    1. Step 1
+    1. Step 2
+    1. Step 3
+
+    Another sentence follows.
 ````
 
 Adhere to the following conventions:
@@ -430,6 +446,8 @@ Adhere to the following conventions:
 - In numbered lists, use `1.` for all items to generate the step numbers automatically.
   You can also use a higher number for the first item to start with that number.
 - Use `-` for unordered lists. When using nested lists, you can use `*` for the nested level.
+- Leave a blank line before starting a list and after ending it.
+- Only use an indentation if you are creating a heirarchical list.
 
 ### Definition lists
 


### PR DESCRIPTION
I have been working a lot in the [ubuntu-server-documentation](https://github.com/canonical/ubuntu-server-documentation) repository, and I noticed that a lot of markdown pages had these inconsistencies:

- No blank lines before starting a list.
- Adding an indentation when starting a non-hierarchical list.

For example, on an [Ubuntu server docs page](https://github.com/canonical/ubuntu-server-documentation/blob/057111aeb79411507dcf511bde55938815871a89/explanation/active-directory/security-identifiers-sids.md?plain=1#L14), in Lines 14-15, you'll notice the blank line issue.
```md
Here are some examples of what an SID looks like:
- `S-1-5-32-544`: this is the so called well-known SID of the built-in (`32`) Administrators (`544`) group
```

On the same [page](https://github.com/canonical/ubuntu-server-documentation/blob/057111aeb79411507dcf511bde55938815871a89/explanation/active-directory/security-identifiers-sids.md?plain=1#L26-L29), you'll notice that in Lines 26-28, the list was properly spaced.
```md
See next:

* [Identity mapping backends](identity-mapping-idmap-backends.md)
```

While this isn't noticeable when the documentation is rendered, readability becomes a problem when contributors are working with the documentation directly in Markdown.

I believe merging this PR will improve the readability of several Canonical documentations on GitHub for new contributors. Since I will be opening a GitHub issue if this PR is merged, new contributors will now have the opportunity to start working on their first GitHub issue that addresses markdown-related fixes. It will be a stepping stone in their journey to getting familiar with Markdown and then contributing to the documentation beyond just Markdown formatting issues.