### PR TITLE
add back style guide pages with archive notice

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -155,7 +155,9 @@ if os.path.exists('./reuse/substitutions.yaml'):
 
 # Add files or directories that should be excluded from processing.
 custom_excludes = [
-    'readme.rst'
+    'readme.rst',
+    'style-guide-myst.md',
+    'style-guide.rst'
 ]
 
 # Add CSS files (located in .sphinx/_static/)

--- a/index.rst
+++ b/index.rst
@@ -6,7 +6,7 @@ This site is archived
 .. warning::
    This website is archived and is no longer maintained. The content has moved to the sites listed below.
 
-   Please update your bookmarks accordingly.
+   Please update your bookmarks and links accordingly.
 
 The internal guide to setting up your documentation with Sphinx and Read the Docs has moved to the `Canonical Reference Library`_. See:
 

--- a/style-guide-myst.md
+++ b/style-guide-myst.md
@@ -1,0 +1,9 @@
+# This site is archived
+
+```{warning}
+
+This website is archived and is no longer maintained. The content has moved to [Starter pack reference: MyST style guide](https://canonical-starter-pack.readthedocs-hosted.com/latest/reference/style-guide-myst).
+
+Please update your bookmarks and links accordingly.
+
+```

--- a/style-guide.rst
+++ b/style-guide.rst
@@ -1,0 +1,7 @@
+This site is archived
+=====================
+
+.. warning::
+   This website is archived and is no longer maintained. The content has moved to: `Starter pack reference: ReStructuredText style guide <https://canonical-starter-pack.readthedocs-hosted.com/latest/reference/style-guide/>`_.
+
+   Please update your bookmarks and links accordingly.


### PR DESCRIPTION
I had previously deleted the style guide pages from the repository. Since this can break existing links from other documentation sets that reference those style guide pages, I've added them back with warning notices about this site being archived and where to find the moved content. Preferring this over an automatic redirect so that people can update their links instead of holding onto the old one forever. 